### PR TITLE
评论系统Bug

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -165,7 +165,6 @@ layout: default
         appId:'ayaP9lToORmhrAv8eyA1BTEx-gzGzoHsz',
         appKey:'F6bhPRHF1V43dbUilx493zGo',
         notify:true,
-        path: '/post/jekyll-%E6%B7%BB%E5%8A%A0-Valine-%E8%AF%84%E8%AE%BA.html',
         placeholder:'✿评论请戳这里✿（如果你只想作为游客访问，填上你喜欢的昵称就好，如果想让我更方便联系你，可以留下你的邮箱或者网址哟≧ ▽ ≦）',
 		avatar:'retro'
     })


### PR DESCRIPTION
评论系统加载所有文章评论。
原因：Valine 初始化的时候，path参数导致的，删除即可。
影响：之前所有的评论都会失效。
